### PR TITLE
Implementation of the ChoiceFilter to create Elastica Filter

### DIFF
--- a/Builder/ElasticaDatagridBuilder.php
+++ b/Builder/ElasticaDatagridBuilder.php
@@ -60,25 +60,29 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
     public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
     {
         // Try to wrap all types to search types
-        $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());
-        $type = $guessType->getType();
-        $fieldDescription->setType($type);
-        $options = $guessType->getOptions();
+    	if ($type == null) { 
+            $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());
+            $type = $guessType->getType();
+            $fieldDescription->setType($type);
+            $options = $guessType->getOptions();
 
-        foreach ($options as $name => $value) {
-            if (is_array($value)) {
-                $fieldDescription->setOption($name, array_merge($value, $fieldDescription->getOption($name, array())));
-            } else {
-                $fieldDescription->setOption($name, $fieldDescription->getOption($name, $value));
+            foreach ($options as $name => $value) {
+                if (is_array($value)) {
+                    $fieldDescription->setOption($name, array_merge($value, $fieldDescription->getOption($name, array())));
+                } else {
+                    $fieldDescription->setOption($name, $fieldDescription->getOption($name, $value));
+                }
             }
+    	}else{
+            $fieldDescription->setType($type);
         }
-
+        $this->fixFieldDescription($admin, $fieldDescription);
         $admin->addFilterFieldDescription($fieldDescription->getName(), $fieldDescription);
 
         $fieldDescription->mergeOption('field_options', array('required' => false));
         $filter = $this->filterFactory->create($fieldDescription->getName(), $type, $fieldDescription->getOptions());
 
-        if (!$filter->getLabel()) {
+        if (false !== $filter->getLabel() && !$filter->getLabel()) {
             $filter->setLabel($admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'filter', 'label'));
         }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -39,5 +39,10 @@
             class="Sonata\AdminSearchBundle\Filter\StringFilter">
             <tag name="sonata.admin.filter.type" alias="elastica_string" />
         </service>
+        <service
+            id="sonata.admin.search.filter.type.choice"
+            class="Sonata\AdminSearchBundle\Filter\ChoiceFilter">
+            <tag name="sonata.admin.filter.type" alias="elastica_choice" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
For one of my project in addition to query, I need to filter my results. I have a filed 'type' in my mongodb documents and I need to search in my db and filter on one or several types.

I did not find out how to do it. But the ChoiceFilter was not implemented yet.
On the base of the StringFilter, I adapt it to make query with filters.

Furthermore, in the ElasticaDatagridBuilder, the type field of the filter was not used and you cannot choose the filter to use. I adapt it from the Sonata\DoctrineORMAdminBundle DatagridBuilder in order to use it.
