### PR TITLE
Fix wrong query term escaping in StringFilter

### DIFF
--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -13,7 +13,6 @@ namespace Sonata\AdminSearchBundle\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Elastica\Util;
 
 class StringFilter extends Filter
 {
@@ -41,7 +40,7 @@ class StringFilter extends Filter
         $queryBuilder
             ->fieldOpen($secondOperator)
                 ->fieldOpen($field)
-                    ->field('query', Util::escapeTerm($data['value']))
+                    ->field('query', str_replace(array('\\', '"'), array('\\\\', '\"'), $data['value']))
                     ->field('operator', 'and')
                 ->fieldClose()
             ->fieldClose();

--- a/Tests/Filter/StringFilterTest.php
+++ b/Tests/Filter/StringFilterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Sonata\AdminSearchBundle\Tests\Filter;
+
+use Sonata\AdminSearchBundle\ProxyQuery\ElasticaProxyQuery;
+use Sonata\AdminSearchBundle\Filter\StringFilter;
+
+class StringFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ElasticaProxyQuery
+     */
+    protected $proxyQuery;
+
+    public function setup()
+    {
+        $finder = $this->getMockBuilder('FOS\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->proxyQuery = new ElasticaProxyQuery($finder);
+    }
+
+    public function testFilterSimple()
+    {
+        $filter = new StringFilter();
+        $value  = 'bar';
+
+        $filter->filter($this->proxyQuery, 'filter', 'foo', array('value' => $value));
+
+        $queryReflection = new \ReflectionClass($this->proxyQuery);
+        $queryProperty   = $queryReflection->getProperty('query');
+
+        $queryProperty->setAccessible(true);
+
+        $queryArray = $queryProperty->getValue($this->proxyQuery)->toArray();
+
+        $this->assertEquals($value, $queryArray['query']['bool']['must'][0]['match']['foo']['query']);
+    }
+
+    /**
+     * Check if filter query with special characters can be translated into JSON
+     */
+    public function testFilterSpecialCharacters()
+    {
+        $filter = new StringFilter();
+        $value  = 'bar \ + - && || ! ( ) { } [ ] ^ " ~ * ? : baz';
+
+        $filter->filter($this->proxyQuery, 'filter', 'foo', array('value' => $value));
+
+        $queryReflection = new \ReflectionClass($this->proxyQuery);
+        $queryProperty   = $queryReflection->getProperty('query');
+
+        $queryProperty->setAccessible(true);
+
+        $queryArray = $queryProperty->getValue($this->proxyQuery)->toArray();
+
+        $this->assertEquals($value, $queryArray['query']['bool']['must'][0]['match']['foo']['query']);
+    }
+}


### PR DESCRIPTION
After a thorough investigation I realized that only two characters must be escaped: " and \

This PR should fix #5.
