### PR TITLE
Implement callback filter.

### DIFF
--- a/Filter/CallbackFilter.php
+++ b/Filter/CallbackFilter.php
@@ -26,13 +26,13 @@ class CallbackFilter extends Filter
     /**
      * {@inheritdoc}
      */
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
+    public function filter(ProxyQueryInterface $query, $alias, $field, $data)
     {
         if (!is_callable($this->getOption('callback'))) {
             throw new \RuntimeException(sprintf('Please provide a valid callback option "filter" for field "%s"', $this->getName()));
         }
 
-        $this->active = call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $data);
+        $this->active = call_user_func($this->getOption('callback'), $query, $alias, $field, $data);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ sonata_admin_search:
             finder: Id for a FOS finder service that should be used # Finder service
 ```
 
+## Documentation
+
+For contribution to the documentation you cand find it on [Resources/doc](https://github.com/sonata-project/SonataAdminSearchBundle/tree/master/Resources/doc).
+
 [0]:https://travis-ci.org/sonata-project/SonataAdminSearchBundle.svg?branch=master
 [1]:https://travis-ci.org/sonata-project/SonataAdminSearchBundle
 [2]:http://sonata-project.org/bundles/admin

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -45,9 +45,14 @@
             <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_choice" />
         </service>
         <service
+            id="sonata.admin.search.filter.type.callback"
+            class="Sonata\AdminSearchBundle\Filter\CallbackFilter">
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_callback" />
+        </service>
+        <service
             id="sonata.admin.search.filter.type.boolean"
             class="Sonata\AdminSearchBundle\Filter\BooleanFilter">
             <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_boolean" />
-        </service>        
+        </service>
     </services>
 </container>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,0 +1,11 @@
+Sonata Admin Search Bundle
+==========================
+
+Reference Guide
+---------------
+
+.. toctree::
+   :maxdepth: 1
+   :numbered:
+
+   reference/filter_field_definition

--- a/Resources/doc/reference/filter_field_definition.rst
+++ b/Resources/doc/reference/filter_field_definition.rst
@@ -1,0 +1,58 @@
+.. index::
+
+Filter field definition
+=======================
+
+Available filter types
+----------------------
+
+* `sonata_search_elastica_boolean`: depends on the ``sonata_type_filter_default`` Form Type, renders yes or no field,
+* `sonata_search_elastica_callback`: depends on the ``sonata_type_filter_default`` Form Type,
+* `sonata_search_elastica_choice`: depends on the ``sonata_type_filter_default`` Form Type,
+* `sonata_search_elastica_string`: depends on the ``sonata_type_filter_choice`` Form Type,
+* `sonata_search_elastica_number`: depends on the ``sonata_type_filter_number`` Form Type
+
+Callback
+^^^^^^^^
+
+To create a custom callback filter, you just need to set the "callback" filter option
+to a valid callback function. First argument of this function will be
+``Sonata\AdminSearchBundle\ProxyQuery\ElasticaProxyQuery`` instance which could be
+modified according to your needs.
+
+.. code-block:: php
+
+    <?php
+    namespace Sonata\NewsBundle\Admin;
+
+    use Sonata\AdminBundle\Admin\Admin;
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\AdminSearchBundle\ProxyQuery\ElasticaProxyQuery;
+
+    class PostAdmin extends Admin
+    {
+        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+        {
+            $datagridMapper
+                ->add('title')
+                ->add('name', 'sonata_search_elastica_callback', array(
+                    'callback' => function (ElasticaProxyQuery $query, $alias, $field, $data) {
+                        if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
+                            return;
+                        }
+
+                        $queryBuilder = new \Elastica\Query\Builder();
+
+                        $queryBuilder
+                            ->fieldOpen('multi_match')
+                                ->field('query', trim($data['value']))
+                                ->field('fields', ['name', 'name.std'])
+                                ->field('operator', 'and')
+                            ->fieldClose();
+
+                        $query->addMust($queryBuilder);
+                    }
+                ))
+            ;
+        }
+    }


### PR DESCRIPTION
This will allow to use "elastica_callback" as a filter type (fix for #8).

Callback can modify original filter query. Here is the usage sample:

``` php
<?php

namespace AppBundle\Admin;

use Sonata\AdminBundle\Admin\Admin;
use Sonata\AdminBundle\Datagrid\DatagridMapper;
use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;

class MyAdmin extends Admin
{
    // ...
    // Fields to be shown on filter forms
    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
    {
        $datagridMapper
            ->add('name', 'elastica_callback', [
                'callback' => function (ProxyQueryInterface $query, $alias, $field, $data) {
                    if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
                        return;
                    }

                    $data['value'] = trim($data['value']);

                    if (strlen($data['value']) == 0) {
                        return;
                    }

                    $queryBuilder = new \Elastica\Query\Builder();

                    // you can use any Elastica query configuration provided by FOSElasticaBundle
                    $queryBuilder
                        ->fieldOpen('multi_match')
                            ->field('query', $data['value'])
                            ->field('fields', ['name', 'name.std'])
                            ->field('operator', 'and')
                        ->fieldClose();

                    $query->addMust($queryBuilder);
                }
            ])
        ;
    }
}
```
