### PR TITLE
Implement the createQuery overriding

### DIFF
--- a/Builder/ElasticaDatagridBuilder.php
+++ b/Builder/ElasticaDatagridBuilder.php
@@ -60,25 +60,29 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
     public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
     {
         // Try to wrap all types to search types
-        $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());
-        $type = $guessType->getType();
-        $fieldDescription->setType($type);
-        $options = $guessType->getOptions();
+    	if ($type == null) { 
+            $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());
+            $type = $guessType->getType();
+            $fieldDescription->setType($type);
+            $options = $guessType->getOptions();
 
-        foreach ($options as $name => $value) {
-            if (is_array($value)) {
-                $fieldDescription->setOption($name, array_merge($value, $fieldDescription->getOption($name, array())));
-            } else {
-                $fieldDescription->setOption($name, $fieldDescription->getOption($name, $value));
+            foreach ($options as $name => $value) {
+                if (is_array($value)) {
+                    $fieldDescription->setOption($name, array_merge($value, $fieldDescription->getOption($name, array())));
+                } else {
+                    $fieldDescription->setOption($name, $fieldDescription->getOption($name, $value));
+                }
             }
+    	}else{
+            $fieldDescription->setType($type);
         }
-
+        $this->fixFieldDescription($admin, $fieldDescription);
         $admin->addFilterFieldDescription($fieldDescription->getName(), $fieldDescription);
 
         $fieldDescription->mergeOption('field_options', array('required' => false));
         $filter = $this->filterFactory->create($fieldDescription->getName(), $type, $fieldDescription->getOptions());
 
-        if (!$filter->getLabel()) {
+        if (false !== $filter->getLabel() && !$filter->getLabel()) {
             $filter->setLabel($admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'filter', 'label'));
         }
 

--- a/Builder/ElasticaDatagridBuilder.php
+++ b/Builder/ElasticaDatagridBuilder.php
@@ -60,7 +60,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
     public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
     {
         // Try to wrap all types to search types
-        if ($type == null) {
+    	if ($type == null) { 
             $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());
             $type = $guessType->getType();
             $fieldDescription->setType($type);
@@ -73,7 +73,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
                     $fieldDescription->setOption($name, $fieldDescription->getOption($name, $value));
                 }
             }
-        } else {
+    	}else{
             $fieldDescription->setType($type);
         }
         $this->fixFieldDescription($admin, $fieldDescription);

--- a/Builder/ElasticaDatagridBuilder.php
+++ b/Builder/ElasticaDatagridBuilder.php
@@ -39,11 +39,11 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
         FinderProviderInterface $finderProvider,
         ManagerInterface $configManager
     ) {
-        $this->formFactory             = $formFactory;
-        $this->filterFactory           = $filterFactory;
-        $this->guesser                 = $guesser;
-        $this->finderProvider          = $finderProvider;
-        $this->configManager           = $configManager;
+        $this->formFactory = $formFactory;
+        $this->filterFactory = $filterFactory;
+        $this->guesser = $guesser;
+        $this->finderProvider = $finderProvider;
+        $this->configManager = $configManager;
     }
 
     /**
@@ -60,7 +60,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
     public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
     {
         // Try to wrap all types to search types
-    	if ($type == null) { 
+        if ($type == null) {
             $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());
             $type = $guessType->getType();
             $fieldDescription->setType($type);
@@ -73,7 +73,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
                     $fieldDescription->setOption($name, $fieldDescription->getOption($name, $value));
                 }
             }
-    	}else{
+        } else {
             $fieldDescription->setType($type);
         }
         $this->fixFieldDescription($admin, $fieldDescription);
@@ -106,9 +106,14 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
             $defaultOptions
         );
 
-        $proxyQuery = new ElasticaProxyQuery(
-            $this->finderProvider->getFinderByAdmin($admin)
-        );
+        $proxyQuery = $admin->createQuery();
+        // if the default modelmanager query builder is used, we need to replace it with elastica
+        // if not, that means $admin->createQuery has been overriden by the user and return already an ElasticaProxyQuery object
+        if (!$proxyQuery instanceof ElasticaProxyQuery) {
+            if ($this->isSmart($admin, $values)) {
+                $proxyQuery = new ElasticaProxyQuery($this->finderProvider->getFinderByAdmin($admin));
+            }
+        }
 
         return new Datagrid(
             $proxyQuery,
@@ -120,7 +125,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
     }
 
     /**
-     * Returns true if this datagrid builder can process these values
+     * Returns true if this datagrid builder can process these values.
      */
     public function isSmart(AdminInterface $admin, array $values = array())
     {
@@ -136,7 +141,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
         // Compare to the fields on wich the search apply
         $smart = true;
 
-        foreach ($values as $key=>$value) {
+        foreach ($values as $key => $value) {
             if (!is_array($value) || !isset($value['value'])) {
                 // This is not a filter field
                 continue;
@@ -148,6 +153,23 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
             }
 
             if (!in_array($key, $mappedFieldNames)) {
+                /*
+                 * We are in the case where a field is used as filter
+                 * without being mapped in elastic search.
+                 * An ugly case would be to have a custom field used in the filter
+                 * without mapping in the model, we need to control that
+                 */
+                $ret = $admin->getModelManager()->getParentMetadataForProperty(
+                    $admin->getClass(),
+                    $key,
+                    $admin->getModelManager()
+                );
+
+                list($metadata, $propertyName, $parentAssociationMappings) = $ret;
+                //Case if a filter is used in the filter but not linked to the ModelManager ("mapped" = false ) case
+                if (!$metadata->hasField($key)) {
+                    break;
+                }
                 // This filter field is not mapped in elasticsearch
                 // so we cannot use elasticsearch
                 $smart = false;

--- a/Builder/ElasticaDatagridBuilder.php
+++ b/Builder/ElasticaDatagridBuilder.php
@@ -60,7 +60,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
     public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
     {
         // Try to wrap all types to search types
-    	if ($type == null) { 
+        if ($type == null) {
             $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());
             $type = $guessType->getType();
             $fieldDescription->setType($type);
@@ -73,7 +73,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
                     $fieldDescription->setOption($name, $fieldDescription->getOption($name, $value));
                 }
             }
-    	}else{
+        } else {
             $fieldDescription->setType($type);
         }
         $this->fixFieldDescription($admin, $fieldDescription);

--- a/Filter/CallbackFilter.php
+++ b/Filter/CallbackFilter.php
@@ -26,13 +26,13 @@ class CallbackFilter extends Filter
     /**
      * {@inheritdoc}
      */
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
+    public function filter(ProxyQueryInterface $query, $alias, $field, $data)
     {
         if (!is_callable($this->getOption('callback'))) {
             throw new \RuntimeException(sprintf('Please provide a valid callback option "filter" for field "%s"', $this->getName()));
         }
 
-        $this->active = call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $data);
+        $this->active = call_user_func($this->getOption('callback'), $query, $alias, $field, $data);
     }
 
     /**

--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -73,33 +73,33 @@ class FilterTypeGuesser implements TypeGuesserInterface
                 $options['field_type']    = 'sonata_type_boolean';
                 $options['field_options'] = array();
 
-                return new TypeGuess('elastic_boolean', $options, Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('sonata_search_elastic_boolean', $options, Guess::HIGH_CONFIDENCE);
             case 'datetime':
             case 'vardatetime':
             case 'datetimetz':
-                return new TypeGuess('elastica_datetime', $options, Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('sonata_search_elastica_datetime', $options, Guess::HIGH_CONFIDENCE);
             case 'date':
-                return new TypeGuess('elastica_date', $options, Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('sonata_search_elastica_date', $options, Guess::HIGH_CONFIDENCE);
             case 'decimal':
             case 'float':
                 $options['field_type'] = 'number';
 
-                return new TypeGuess('elastica_number', $options, Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('sonata_search_elastica_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'integer':
             case 'bigint':
             case 'smallint':
                 $options['field_type'] = 'number';
 
-                return new TypeGuess('elastica_number', $options, Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('sonata_search_elastica_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'string':
             case 'text':
                 $options['field_type'] = 'text';
 
-                return new TypeGuess('elastica_string', $options, Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('sonata_search_elastica_string', $options, Guess::MEDIUM_CONFIDENCE);
             case 'time':
-                return new TypeGuess('elastica_time', $options, Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('sonata_search_elastica_time', $options, Guess::HIGH_CONFIDENCE);
             default:
-                return new TypeGuess('elastica_string', $options, Guess::LOW_CONFIDENCE);
+                return new TypeGuess('sonata_search_elastica_string', $options, Guess::LOW_CONFIDENCE);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ sonata_admin_search:
             finder: Id for a FOS finder service that should be used # Finder service
 ```
 
+## Documentation
+
+For contribution to the documentation you cand find it on [Resources/doc](https://github.com/sonata-project/SonataAdminSearchBundle/tree/master/Resources/doc).
+
 [0]:https://travis-ci.org/sonata-project/SonataAdminSearchBundle.svg?branch=master
 [1]:https://travis-ci.org/sonata-project/SonataAdminSearchBundle
 [2]:http://sonata-project.org/bundles/admin

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -39,5 +39,10 @@
             class="Sonata\AdminSearchBundle\Filter\StringFilter">
             <tag name="sonata.admin.filter.type" alias="elastica_string" />
         </service>
+        <service
+            id="sonata.admin.search.filter.type.choice"
+            class="Sonata\AdminSearchBundle\Filter\ChoiceFilter">
+            <tag name="sonata.admin.filter.type" alias="elastica_choice" />
+        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -45,9 +45,14 @@
             <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_choice" />
         </service>
         <service
+            id="sonata.admin.search.filter.type.callback"
+            class="Sonata\AdminSearchBundle\Filter\CallbackFilter">
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_callback" />
+        </service>
+        <service
             id="sonata.admin.search.filter.type.boolean"
             class="Sonata\AdminSearchBundle\Filter\BooleanFilter">
             <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_boolean" />
-        </service>        
+        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -42,7 +42,12 @@
         <service
             id="sonata.admin.search.filter.type.choice"
             class="Sonata\AdminSearchBundle\Filter\ChoiceFilter">
-            <tag name="sonata.admin.filter.type" alias="elastica_choice" />
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_choice" />
         </service>
+        <service
+            id="sonata.admin.search.filter.type.boolean"
+            class="Sonata\AdminSearchBundle\Filter\BooleanFilter">
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_boolean" />
+        </service>        
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -32,12 +32,12 @@
         <service
             id="sonata.admin.search.filter.type.number"
             class="Sonata\AdminSearchBundle\Filter\NumberFilter">
-            <tag name="sonata.admin.filter.type" alias="elastica_number" />
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_number" />
         </service>
         <service
             id="sonata.admin.search.filter.type.string"
             class="Sonata\AdminSearchBundle\Filter\StringFilter">
-            <tag name="sonata.admin.filter.type" alias="elastica_string" />
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_string" />
         </service>
         <service
             id="sonata.admin.search.filter.type.choice"

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -54,10 +54,5 @@
             class="Sonata\AdminSearchBundle\Filter\BooleanFilter">
             <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_boolean" />
         </service>
-        <service
-            id="sonata.admin.search.filter.type.choice"
-            class="Sonata\AdminSearchBundle\Filter\ChoiceFilter">
-            <tag name="sonata.admin.filter.type" alias="elastica_choice" />
-        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -53,6 +53,6 @@
             id="sonata.admin.search.filter.type.boolean"
             class="Sonata\AdminSearchBundle\Filter\BooleanFilter">
             <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_boolean" />
-        </service>        
+        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -54,5 +54,10 @@
             class="Sonata\AdminSearchBundle\Filter\BooleanFilter">
             <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_boolean" />
         </service>
+        <service
+            id="sonata.admin.search.filter.type.choice"
+            class="Sonata\AdminSearchBundle\Filter\ChoiceFilter">
+            <tag name="sonata.admin.filter.type" alias="elastica_choice" />
+        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -53,6 +53,6 @@
             id="sonata.admin.search.filter.type.boolean"
             class="Sonata\AdminSearchBundle\Filter\BooleanFilter">
             <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_boolean" />
-        </service>
+        </service>        
     </services>
 </container>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,0 +1,11 @@
+Sonata Admin Search Bundle
+==========================
+
+Reference Guide
+---------------
+
+.. toctree::
+   :maxdepth: 1
+   :numbered:
+
+   reference/filter_field_definition

--- a/Resources/doc/reference/filter_field_definition.rst
+++ b/Resources/doc/reference/filter_field_definition.rst
@@ -1,0 +1,58 @@
+.. index::
+
+Filter field definition
+=======================
+
+Available filter types
+----------------------
+
+* `sonata_search_elastica_boolean`: depends on the ``sonata_type_filter_default`` Form Type, renders yes or no field,
+* `sonata_search_elastica_callback`: depends on the ``sonata_type_filter_default`` Form Type,
+* `sonata_search_elastica_choice`: depends on the ``sonata_type_filter_default`` Form Type,
+* `sonata_search_elastica_string`: depends on the ``sonata_type_filter_choice`` Form Type,
+* `sonata_search_elastica_number`: depends on the ``sonata_type_filter_number`` Form Type
+
+Callback
+^^^^^^^^
+
+To create a custom callback filter, you just need to set the "callback" filter option
+to a valid callback function. First argument of this function will be
+``Sonata\AdminSearchBundle\ProxyQuery\ElasticaProxyQuery`` instance which could be
+modified according to your needs.
+
+.. code-block:: php
+
+    <?php
+    namespace Sonata\NewsBundle\Admin;
+
+    use Sonata\AdminBundle\Admin\Admin;
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\AdminSearchBundle\ProxyQuery\ElasticaProxyQuery;
+
+    class PostAdmin extends Admin
+    {
+        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+        {
+            $datagridMapper
+                ->add('title')
+                ->add('name', 'sonata_search_elastica_callback', array(
+                    'callback' => function (ElasticaProxyQuery $query, $alias, $field, $data) {
+                        if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
+                            return;
+                        }
+
+                        $queryBuilder = new \Elastica\Query\Builder();
+
+                        $queryBuilder
+                            ->fieldOpen('multi_match')
+                                ->field('query', trim($data['value']))
+                                ->field('fields', ['name', 'name.std'])
+                                ->field('operator', 'and')
+                            ->fieldClose();
+
+                        $query->addMust($queryBuilder);
+                    }
+                ))
+            ;
+        }
+    }

--- a/Resources/meta/LICENSE
+++ b/Resources/meta/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2010-2013 thomas.rabaix@sonata-project.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Tests/Filter/BooleanFilterTest.php
+++ b/Tests/Filter/BooleanFilterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Sonata\AdminSearchBundle\Tests\Filter;
+
+use Sonata\AdminSearchBundle\ProxyQuery\ElasticaProxyQuery;
+use Sonata\AdminSearchBundle\Filter\BooleanFilter;
+use Sonata\CoreBundle\Form\Type\BooleanType;
+
+class BooleanFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ElasticaProxyQuery
+     */
+    protected $proxyQuery;
+
+    public function setup()
+    {
+        $finder = $this->getMockBuilder('FOS\ElasticaBundle\Finder\TransformedFinder')
+        ->disableOriginalConstructor()
+        ->getMock();
+
+        $this->proxyQuery = new ElasticaProxyQuery($finder);
+    }
+
+    public function testNoFilterSimple()
+    {
+        $filter = new BooleanFilter();
+        $value  = BooleanType::TYPE_NO;
+
+        $filter->filter($this->proxyQuery, 'filter', 'foo', array('value' => $value, 'type'=> null));
+
+        $queryReflection = new \ReflectionClass($this->proxyQuery);
+        $queryProperty   = $queryReflection->getProperty('query');
+
+        $queryProperty->setAccessible(true);
+
+        $queryArray = $queryProperty->getValue($this->proxyQuery)->toArray();
+
+        $this->assertEquals('false', $queryArray['query']['bool']['must'][0]['term']['foo']);
+    }
+
+    public function testYesFilterSimple()
+    {
+        $filter = new BooleanFilter();
+        $value  = BooleanType::TYPE_YES;
+
+        $filter->filter($this->proxyQuery, 'filter', 'foo', array('value' => $value, 'type'=> null));
+
+        $queryReflection = new \ReflectionClass($this->proxyQuery);
+        $queryProperty   = $queryReflection->getProperty('query');
+
+        $queryProperty->setAccessible(true);
+
+        $queryArray = $queryProperty->getValue($this->proxyQuery)->toArray();
+         
+        $this->assertEquals('true', $queryArray['query']['bool']['must'][0]['term']['foo']);
+    }
+
+}


### PR DESCRIPTION
The proxyQuery passed to the Datagrid was hard coded. Here, it check if the createQuery is overridden by the user and return an ElasticaProxyQuery and if it’s a smart query. Else, the original model manager is used instead of ElasticSearch.
