### PR TITLE
Implement the createQuery overriding

### DIFF
--- a/Builder/ElasticaDatagridBuilder.php
+++ b/Builder/ElasticaDatagridBuilder.php
@@ -39,11 +39,11 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
         FinderProviderInterface $finderProvider,
         ManagerInterface $configManager
     ) {
-        $this->formFactory             = $formFactory;
-        $this->filterFactory           = $filterFactory;
-        $this->guesser                 = $guesser;
-        $this->finderProvider          = $finderProvider;
-        $this->configManager           = $configManager;
+        $this->formFactory = $formFactory;
+        $this->filterFactory = $filterFactory;
+        $this->guesser = $guesser;
+        $this->finderProvider = $finderProvider;
+        $this->configManager = $configManager;
     }
 
     /**
@@ -60,7 +60,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
     public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
     {
         // Try to wrap all types to search types
-    	if ($type == null) { 
+        if ($type == null) {
             $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());
             $type = $guessType->getType();
             $fieldDescription->setType($type);
@@ -73,7 +73,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
                     $fieldDescription->setOption($name, $fieldDescription->getOption($name, $value));
                 }
             }
-    	}else{
+        } else {
             $fieldDescription->setType($type);
         }
         $this->fixFieldDescription($admin, $fieldDescription);
@@ -120,7 +120,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
     }
 
     /**
-     * Returns true if this datagrid builder can process these values
+     * Returns true if this datagrid builder can process these values.
      */
     public function isSmart(AdminInterface $admin, array $values = array())
     {
@@ -136,7 +136,7 @@ class ElasticaDatagridBuilder implements DatagridBuilderInterface
         // Compare to the fields on wich the search apply
         $smart = true;
 
-        foreach ($values as $key=>$value) {
+        foreach ($values as $key => $value) {
             if (!is_array($value) || !isset($value['value'])) {
                 // This is not a filter field
                 continue;

--- a/Resources/doc/reference/createquery.rst
+++ b/Resources/doc/reference/createquery.rst
@@ -1,0 +1,21 @@
+Customizing the query used to generate the list
+===============================================
+
+
+You can customize the list query thanks to the ``createQuery`` method.
+
+.. code-block:: php
+
+    <?php
+
+    public function createQuery($context = 'list')
+    {
+        $query = parent::createQuery($context);
+
+        $queryparam = new \Elastica\Query\Match();
+        $queryparam->setFieldQuery('my_param', 'my_value');
+        $query->addMust($queryparam);
+
+        return $query;
+    }
+


### PR DESCRIPTION
The proxyQuery passed to the Datagrid was hard coded. Here, it check if the createQuery is overridden by the user and return an ElasticaProxyQuery and if it’s a smart query. Else, the original model manager is used instead of ElasticSearch.
