### PR TITLE
Implement DateFilter

### DIFF
--- a/Filter/AbstractDateFilter.php
+++ b/Filter/AbstractDateFilter.php
@@ -25,12 +25,15 @@ abstract class AbstractDateFilter extends Filter
     /**
      * {@inheritdoc}
      */
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
+    public function filter(ProxyQueryInterface $query, $alias, $field, $data)
     {
         // check data sanity
         if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
             return;
         }
+
+        $format = array_key_exists('format', $this->getFieldOptions()) ? $this->getFieldOptions()['format'] : 'c';
+        $queryBuilder = new \Elastica\Query\Builder();
 
         if ($this->range) {
             // additional data check for ranged items
@@ -51,26 +54,26 @@ abstract class AbstractDateFilter extends Filter
             // default type for range filter
             $data['type'] = !isset($data['type']) || !is_numeric($data['type']) ? DateRangeType::TYPE_BETWEEN : $data['type'];
 
-            $startDateParameterName = $this->getNewParameterName($queryBuilder);
-            $endDateParameterName = $this->getNewParameterName($queryBuilder);
+            $queryBuilder
+                ->fieldOpen('range')
+                    ->fieldOpen($field)
+                        ->field('gte', $data['value']['start']->format($format))
+                        ->field('lte', $data['value']['end']->format($format))
+                    ->fieldClose()
+                ->fieldClose();
 
             if ($data['type'] == DateRangeType::TYPE_NOT_BETWEEN) {
-                $this->applyWhere($queryBuilder, sprintf('%s.%s < :%s OR %s.%s > :%s', $alias, $field, $startDateParameterName, $alias, $field, $endDateParameterName));
+                $query->addMustNot($queryBuilder);
             } else {
-                $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, '>=', $startDateParameterName));
-                $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, '<=', $endDateParameterName));
+                $query->addMust($queryBuilder);
             }
-
-            $queryBuilder->setParameter($startDateParameterName,  $data['value']['start']);
-            $queryBuilder->setParameter($endDateParameterName,  $data['value']['end']);
         } else {
             if (!$data['value']) {
                 return;
             }
 
             // default type for simple filter
-            $data['type'] = !isset($data['type']) || !is_numeric($data['type']) ? DateType::TYPE_EQUAL : $data['type'];
-
+            $data['type'] = !isset($data['type']) || !is_numeric($data['type']) ? DateType::TYPE_GREATER_EQUAL : $data['type'];
             // just find an operator and apply query
             $operator = $this->getOperator($data['type']);
 
@@ -80,14 +83,28 @@ abstract class AbstractDateFilter extends Filter
             }
 
             // null / not null only check for col
-            if (in_array($operator, array('NULL', 'NOT NULL'))) {
-                $this->applyWhere($queryBuilder, sprintf('%s.%s IS %s ', $alias, $field, $operator));
+            if (in_array($operator, array('missing', 'exists'))) {
+                $queryBuilder
+                    ->fieldOpen($operator)
+                        ->field('field', $field)
+                    ->fieldClose();
+            } elseif ($operator == '=') {
+                $queryBuilder
+                    ->fieldOpen('range')
+                        ->fieldOpen($field)
+                          ->field('gte', $data['value']->format($format))
+                          ->field('lte', $data['value']->format($format))
+                      ->fieldClose()
+                  ->fieldClose();
             } else {
-                $parameterName = $this->getNewParameterName($queryBuilder);
-
-                $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
-                $queryBuilder->setParameter($parameterName, $data['value']);
+                $queryBuilder
+                    ->fieldOpen('range')
+                        ->fieldOpen($field)
+                            ->field($operator, $data['value']->format($format))
+                        ->fieldClose()
+                    ->fieldClose();
             }
+            $query->addMust($queryBuilder);
         }
     }
 
@@ -103,13 +120,13 @@ abstract class AbstractDateFilter extends Filter
         $type = intval($type);
 
         $choices = array(
-            DateType::TYPE_EQUAL            => '=',
-            DateType::TYPE_GREATER_EQUAL    => '>=',
-            DateType::TYPE_GREATER_THAN     => '>',
-            DateType::TYPE_LESS_EQUAL       => '<=',
-            DateType::TYPE_LESS_THAN        => '<',
-            DateType::TYPE_NULL             => 'NULL',
-            DateType::TYPE_NOT_NULL         => 'NOT NULL',
+            DateType::TYPE_EQUAL => '=',
+            DateType::TYPE_GREATER_EQUAL => 'gte',
+            DateType::TYPE_GREATER_THAN => 'gt',
+            DateType::TYPE_LESS_EQUAL => 'lte',
+            DateType::TYPE_LESS_THAN => 'lt',
+            DateType::TYPE_NULL => 'missing',
+            DateType::TYPE_NOT_NULL => 'exists',
         );
 
         return isset($choices[$type]) ? $choices[$type] : '=';

--- a/Filter/AbstractDateFilter.php
+++ b/Filter/AbstractDateFilter.php
@@ -9,14 +9,16 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 abstract class AbstractDateFilter extends Filter
 {
     /**
-     * Flag indicating that filter will have range
-     * @var boolean
+     * Flag indicating that filter will have range.
+     *
+     * @var bool
      */
     protected $range = false;
 
     /**
-     * Flag indicating that filter will filter by datetime instead by date
-     * @var boolean
+     * Flag indicating that filter will filter by datetime instead by date.
+     *
+     * @var bool
      */
     protected $time = false;
 
@@ -47,7 +49,7 @@ abstract class AbstractDateFilter extends Filter
             }
 
             // default type for range filter
-            $data['type'] = !isset($data['type']) || !is_numeric($data['type']) ?  DateRangeType::TYPE_BETWEEN : $data['type'];
+            $data['type'] = !isset($data['type']) || !is_numeric($data['type']) ? DateRangeType::TYPE_BETWEEN : $data['type'];
 
             $startDateParameterName = $this->getNewParameterName($queryBuilder);
             $endDateParameterName = $this->getNewParameterName($queryBuilder);
@@ -62,7 +64,6 @@ abstract class AbstractDateFilter extends Filter
             $queryBuilder->setParameter($startDateParameterName,  $data['value']['start']);
             $queryBuilder->setParameter($endDateParameterName,  $data['value']['end']);
         } else {
-
             if (!$data['value']) {
                 return;
             }
@@ -91,9 +92,9 @@ abstract class AbstractDateFilter extends Filter
     }
 
     /**
-     * Resolves DataType:: constants to SQL operators
+     * Resolves DataType:: constants to SQL operators.
      *
-     * @param integer $type
+     * @param int $type
      *
      * @return string
      */
@@ -120,7 +121,7 @@ abstract class AbstractDateFilter extends Filter
     public function getDefaultOptions()
     {
         return array(
-            'input_type' => 'datetime'
+            'input_type' => 'datetime',
         );
     }
 
@@ -139,10 +140,13 @@ abstract class AbstractDateFilter extends Filter
             $name .= '_range';
         }
 
-        return array($name, array(
-            'field_type'    => $this->getFieldType(),
-            'field_options' => $this->getFieldOptions(),
-            'label'         => $this->getLabel(),
-        ));
+        return array(
+            $name,
+            array(
+                'field_type' => $this->getFieldType(),
+                'field_options' => $this->getFieldOptions(),
+                'label' => $this->getLabel(),
+            ),
+        );
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -54,5 +54,25 @@
             class="Sonata\AdminSearchBundle\Filter\BooleanFilter">
             <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_boolean" />
         </service>
+        <service
+            id="sonata.admin.search.filter.type.date"
+            class="Sonata\AdminSearchBundle\Filter\DateFilter">
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_date" />
+        </service>        
+        <service
+            id="sonata.admin.search.filter.type.date.range"
+            class="Sonata\AdminSearchBundle\Filter\DateRangeFilter">
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_date_range" />
+        </service>  
+        <service
+            id="sonata.admin.search.filter.type.datetime"
+            class="Sonata\AdminSearchBundle\Filter\DateTimeFilter">
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_datetime" />
+        </service>        
+        <service
+            id="sonata.admin.search.filter.type.datetime.range"
+            class="Sonata\AdminSearchBundle\Filter\DateTimeRangeFilter">
+            <tag name="sonata.admin.filter.type" alias="sonata_search_elastica_datetime_range" />
+        </service>
     </services>
 </container>

--- a/Resources/doc/reference/filter_field_definition.rst
+++ b/Resources/doc/reference/filter_field_definition.rst
@@ -10,7 +10,11 @@ Available filter types
 * `sonata_search_elastica_callback`: depends on the ``sonata_type_filter_default`` Form Type,
 * `sonata_search_elastica_choice`: depends on the ``sonata_type_filter_default`` Form Type,
 * `sonata_search_elastica_string`: depends on the ``sonata_type_filter_choice`` Form Type,
-* `sonata_search_elastica_number`: depends on the ``sonata_type_filter_number`` Form Type
+* `sonata_search_elastica_number`: depends on the ``sonata_type_filter_number`` Form Type,
+* `sonata_search_elastica_date` : depends on the ``sonata_type_filter_date`` From Type, renders a date field,
+* `sonata_search_elastica_date_range` : depends on the ``sonata_type_filter_date_range`` From Type, renders a 2 date fields,
+* `sonata_search_elastica_datetime` : depends on the ``sonata_type_filter_datetime`` From Type, renders a datetime field,
+* `sonata_search_elastica_datetime_range` : depends on the ``sonata_type_filter_datetime_range`` From Type, renders a 2 datetime fields.
 
 Callback
 ^^^^^^^^
@@ -56,3 +60,25 @@ modified according to your needs.
             ;
         }
     }
+
+
+Date
+^^^^
+
+To make query on date/datetime type, you can use one of the `sonata_search_elastica_date` filter types.
+For example if you have a date in the ISO 8601 date format :
+
+.. code-block:: php
+        
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper
+            ->add('date', 'sonata_search_elastica_datetime', null, 'datetime', array(
+                'format' => 'c'
+            ))        
+        ;
+    }
+
+The format must be a string formatted according to the `php format date`_ and be the one used to map the data in elasticsearch. If it is not the same, ElasticSearch will raise an exception ``failed to parse date field [15/05/28] Invalid format``
+
+.. _php format date: http://php.net/manual/en/function.date.php


### PR DESCRIPTION
In order to make query on date/datetime type, I implement the AbstractDateFilter.
For example if you have a date in the ISO 8601 date format :

```
->add('date', 'sonata_search_elastica_datetime', null, 'datetime', array(
            'format' => 'c'
        ))
```

The format must be a string formatted according to the [php format date](http://php.net/manual/en/function.date.php) and be the one used to mapped the data in elasticsearch. If it is not the same, ElasticSearch will raise an exception `failed to parse date field [15/05/28] Invalid format`

You can define : 
- sonata_search_elastica_date
- sonata_search_elastica_datetime
- sonata_search_elastica_date_range
- sonata_search_elastica_datetime_range

I can't find example of tests for the ORM DateFilter so I don't know how to write some.
