### PR TITLE
remove vendor directory from the cache directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.cache/pip
-    - vendor
 
 env:
   global:


### PR DESCRIPTION
This should make compose able to fallback to a different installation
method if the first one fails.
@see
https://github.com/composer/composer/issues/4147#issuecomment-115258930
