### PR TITLE
Move documentation to reStructuredText format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,6 @@
 
 [![Build Status][0]][1]
 
-By default, [SonataAdminBundle][2] uses the storage backend full-text search
-capabilities to provide search results or filtered listings. This bundle should
-help you leverage the power of your search engine when full-text search is not
-good enough.
-
-For the moment, only [elasticsearch][3] is supported, with the help of
-[FOSElasticaBundle][4] finder services.
-
-## Installation
-
-    composer require sonata-project/admin-search-bundle
-
-## Configuration
-
-You need to map each admin to a FOS finder service that should be used for that
-admin.
-
-```yaml
-sonata_admin_search:
-    admin_finder_services:
-        my_admin.id: # Admin service id
-            finder: Id for a FOS finder service that should be used # Finder service
-            actions : [list] #[Optional] actions where elasticsearch has to be enabled
-```
 
 ## Documentation
 
@@ -33,6 +9,3 @@ For contribution to the documentation you cand find it on [Resources/doc](https:
 
 [0]:https://travis-ci.org/sonata-project/SonataAdminSearchBundle.svg?branch=master
 [1]:https://travis-ci.org/sonata-project/SonataAdminSearchBundle
-[2]:http://sonata-project.org/bundles/admin
-[3]:http://www.elasticsearch.org/
-[4]:https://github.com/FriendsOfSymfony/FOSElasticaBundle

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,10 +1,22 @@
 Sonata Admin Search Bundle
 ==========================
 
+By default, SonataAdminBundle_ uses the storage backend full-text search
+capabilities to provide search results or filtered listings. This bundle should
+help you leverage the power of your search engine when full-text search is not
+good enough.
+
+For the moment, only elasticsearch_ is supported, with the help of
+FOSElasticaBundle_ finder services.
+
 Warning: there is no stable release at the moment, so don't use this bundle
 if you're not willing to do what it takes to fix it when it breaks.
 There is no main developer for it at the moment,
 but we do review and merge PRs pretty quickly.
+
+.. _SonataAdminBundle: http://sonata-project.org/bundles/admin
+.. _elasticsearch: http://www.elasticsearch.org/
+.. _FOSElasticaBundle: https://github.com/FriendsOfSymfony/FOSElasticaBundle
 
 Reference Guide
 ---------------
@@ -13,5 +25,7 @@ Reference Guide
    :maxdepth: 1
    :numbered:
 
+   reference/installation
+   reference/configuration
    reference/createquery
    reference/filter_field_definition

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -1,0 +1,13 @@
+Configuration
+-------------
+
+You need to map each admin to a FOS finder service that should be used for that
+admin.
+
+.. code-block:: yaml
+
+    sonata_admin_search:
+        admin_finder_services:
+            my_admin.id: # Admin service id
+                finder: Id for a FOS finder service that should be used # Finder service
+                actions : [list] #[Optional] actions where elasticsearch has to be enabled

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -1,0 +1,8 @@
+Installation
+------------
+
+The recommended installation method is using the Composer package manager:
+
+.. code-block:: bash
+
+    composer require sonata-project/admin-search-bundle


### PR DESCRIPTION
## Subject

The README is going to be wiped out by dev-kit, and it might be nice to
display this on the website.
