### PR TITLE
Remove internal test classes from autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,14 @@
     "suggest": {
     },
     "autoload": {
-        "psr-4": { "Sonata\\AdminSearchBundle\\": "" }
+        "psr-4": { "Sonata\\AdminSearchBundle\\": "" },
+        "exclude-from-classmap": [
+            "Tests/"
+        ]
     },
+    "autoload-dev": {
+        "psr-4": { "Sonata\\AdminSearchBundle\\Tests\\": "Tests/" }
+     },
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because test classes shouldn't be used by anybody. 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to https://github.com/sonata-project/dev-kit/issues/179
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Removed
- internal test classes are now excluded from the autoloader
```
## Subject

Tests for internal components shouldn't be loaded in production or extended by other bundles.
