### PR TITLE
added captions to TOC tree in docs

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -18,10 +18,9 @@ but we do review and merge PRs pretty quickly.
 .. _elasticsearch: http://www.elasticsearch.org/
 .. _FOSElasticaBundle: https://github.com/FriendsOfSymfony/FOSElasticaBundle
 
-Reference Guide
----------------
-
 .. toctree::
+   :caption: Reference Guide
+   :name: reference-guide
    :maxdepth: 1
    :numbered:
 


### PR DESCRIPTION
I am targeting this branch, because this is a docs change.

## Subject

Added captions to toc tree

This PR is based on the change of @dmarkowicz in https://github.com/sonata-project/SonataAdminBundle/pull/4387
