### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/Resources/doc/reference/filter_field_definition.rst
+++ b/Resources/doc/reference/filter_field_definition.rst
@@ -37,7 +37,7 @@ modified according to your needs.
         {
             $datagridMapper
                 ->add('title')
-                ->add('name', 'sonata_search_elastica_callback', array(
+                ->add('name', Sonata\AdminSearchBundle\Filter\CallbackFilter::class, array(
                     'callback' => function (ElasticaProxyQuery $query, $alias, $field, $data) {
                         if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
                             return;
@@ -71,7 +71,7 @@ For example if you have a date in the ISO 8601 date format :
     protected function configureDatagridFilters(DatagridMapper $datagridMapper)
     {
         $datagridMapper
-            ->add('date', 'sonata_search_elastica_datetime', null, 'datetime', array(
+            ->add('date', Sonata\AdminSearchBundle\Filter\DateTimeFilter::class, null, 'datetime', array(
                 'format' => 'c'
             ))        
         ;

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "friendsofsymfony/elastica-bundle": "^3.1",
         "pagerfanta/pagerfanta": "^1.0",
         "ruflin/elastica": "^2.1 || ^3.0",
         "sonata-project/admin-bundle": "^3.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-config-test": "^0.4.0 || ^1.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^0.7.1",
+        "matthiasnoback/symfony-config-test": "^2.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
     },


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for old versions of php and Symfony
```
