### PR TITLE
Drop PHPUnit 4

### DIFF
--- a/Tests/Filter/BooleanFilterTest.php
+++ b/Tests/Filter/BooleanFilterTest.php
@@ -11,11 +11,12 @@
 
 namespace Sonata\AdminSearchBundle\Tests\Filter;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\AdminSearchBundle\Filter\BooleanFilter;
 use Sonata\AdminSearchBundle\ProxyQuery\ElasticaProxyQuery;
 use Sonata\CoreBundle\Form\Type\BooleanType;
 
-class BooleanFilterTest extends \PHPUnit_Framework_TestCase
+class BooleanFilterTest extends TestCase
 {
     /**
      * @var ElasticaProxyQuery

--- a/Tests/Filter/StringFilterTest.php
+++ b/Tests/Filter/StringFilterTest.php
@@ -11,10 +11,11 @@
 
 namespace Sonata\AdminSearchBundle\Tests\Filter;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\AdminSearchBundle\Filter\StringFilter;
 use Sonata\AdminSearchBundle\ProxyQuery\ElasticaProxyQuery;
 
-class StringFilterTest extends \PHPUnit_Framework_TestCase
+class StringFilterTest extends TestCase
 {
     /**
      * @var ElasticaProxyQuery

--- a/Tests/Model/FinderProviderTest.php
+++ b/Tests/Model/FinderProviderTest.php
@@ -11,14 +11,15 @@
 
 namespace Sonata\AdminSearchBundle\Tests\Model;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\AdminSearchBundle\Model\FinderProvider;
 
-class FinderProviderTest extends \PHPUnit_Framework_TestCase
+class FinderProviderTest extends TestCase
 {
     public function testGetFinderByAdmin()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $provider = new FinderProvider(
             $container,
             [

--- a/Tests/ProxyQuery/ElasticaProxyQueryTest.php
+++ b/Tests/ProxyQuery/ElasticaProxyQueryTest.php
@@ -12,9 +12,10 @@
 namespace Sonata\AdminSearchBundle\Tests\ProxyQuery;
 
 use FOS\ElasticaBundle\Finder\TransformedFinder;
+use PHPUnit\Framework\TestCase;
 use Sonata\AdminSearchBundle\ProxyQuery\ElasticaProxyQuery;
 
-class ElasticaProxyQueryTest extends \PHPUnit_Framework_TestCase
+class ElasticaProxyQueryTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|TransformedFinder


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Removed compatibility with PHPUnit 4. Fixes: https://github.com/sebastianbergmann/phpunit/issues/2809