### PR TITLE
remove deprecated strings for form types

### DIFF
--- a/Tests/Filter/DateFilterTest.php
+++ b/Tests/Filter/DateFilterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminSearchBundle\Tests\Filter;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Form\Type\Filter\DateType;
+use Sonata\AdminSearchBundle\Filter\DateFilter;
+
+/**
+ * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ */
+class DateFilterTest extends TestCase
+{
+    public function testGetFilterTypeClass()
+    {
+        $filter = new DateFilter();
+
+        $renderSettings = $filter->getRenderSettings();
+
+        $this->assertSame(DateType::class, $renderSettings[0]);
+    }
+}

--- a/Tests/Filter/DateRangeFilterTest.php
+++ b/Tests/Filter/DateRangeFilterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminSearchBundle\Tests\Filter;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
+use Sonata\AdminSearchBundle\Filter\DateRangeFilter;
+
+/**
+ * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ */
+class DateRangeFilterTest extends TestCase
+{
+    public function testGetFilterTypeClass()
+    {
+        $filter = new DateRangeFilter();
+
+        $renderSettings = $filter->getRenderSettings();
+
+        $this->assertSame(DateRangeType::class, $renderSettings[0]);
+    }
+}

--- a/Tests/Filter/DateTimeFilterTest.php
+++ b/Tests/Filter/DateTimeFilterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminSearchBundle\Tests\Filter;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
+use Sonata\AdminSearchBundle\Filter\DateTimeFilter;
+
+/**
+ * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ */
+class DateTimeFilterTest extends TestCase
+{
+    public function testGetFilterTypeClass()
+    {
+        $filter = new DateTimeFilter();
+
+        $renderSettings = $filter->getRenderSettings();
+
+        $this->assertSame(DateTimeType::class, $renderSettings[0]);
+    }
+}

--- a/Tests/Filter/DateTimeRangeFilterTest.php
+++ b/Tests/Filter/DateTimeRangeFilterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminSearchBundle\Tests\Filter;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
+use Sonata\AdminSearchBundle\Filter\DateTimeRangeFilter;
+
+/**
+ * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ */
+class DateTimeRangeFilterTest extends TestCase
+{
+    public function testGetFilterTypeClass()
+    {
+        $filter = new DateTimeRangeFilter();
+
+        $renderSettings = $filter->getRenderSettings();
+
+        $this->assertSame(DateTimeRangeType::class, $renderSettings[0]);
+    }
+}

--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,2 +1,5 @@
 UPGRADE 1.x
 ===========
+
+### Deprecated
+- Properties `time` and `range` in `Sonata\AdminSearchBundle\Filter\AbstractDateFilter` are deprecated. Implement `getFilterTypeClass` method.

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminSearchBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
 use Sonata\AdminBundle\Form\Type\Filter\DateType;
 
 abstract class AbstractDateFilter extends Filter
@@ -21,6 +22,10 @@ abstract class AbstractDateFilter extends Filter
      * Flag indicating that filter will have range.
      *
      * @var bool
+     *
+     * NEXT_MAJOR: Remove this property
+     *
+     * @deprecated since 1.x, will be removed in 2.0.
      */
     protected $range = false;
 
@@ -28,6 +33,10 @@ abstract class AbstractDateFilter extends Filter
      * Flag indicating that filter will filter by datetime instead by date.
      *
      * @var bool
+     *
+     * NEXT_MAJOR: Remove this property
+     *
+     * @deprecated since 1.x, will be removed in 2.0.
      */
     protected $time = false;
 
@@ -44,7 +53,23 @@ abstract class AbstractDateFilter extends Filter
         $format = array_key_exists('format', $this->getFieldOptions()) ? $this->getFieldOptions()['format'] : 'c';
         $queryBuilder = new \Elastica\Query\Builder();
 
-        if ($this->range) {
+        /*
+         * NEXT_MAJOR: Use ($this instanceof RangeFilterInterface) for if statement, remove deprecated range.
+         */
+        if (!($range = $this instanceof RangeFilterInterface)) {
+            @trigger_error(
+                sprintf(
+                    'Using `range` property is deprecated since version 1.x, will be removed in 2.0.'.
+                    ' Implement %s instead.',
+                    RangeFilterInterface::class
+                ),
+                E_USER_DEPRECATED
+            );
+
+            $range = $this->range;
+        }
+
+        if ($range) {
             // additional data check for ranged items
             if (!array_key_exists('start', $data['value']) || !array_key_exists('end', $data['value'])) {
                 return;
@@ -132,24 +157,29 @@ abstract class AbstractDateFilter extends Filter
      */
     public function getRenderSettings()
     {
-        $name = 'sonata_type_filter_date';
-
-        if ($this->time) {
-            $name .= 'time';
-        }
-
-        if ($this->range) {
-            $name .= '_range';
-        }
-
         return [
-            $name,
+            $this->getFilterTypeClass(),
             [
                 'field_type' => $this->getFieldType(),
                 'field_options' => $this->getFieldOptions(),
                 'label' => $this->getLabel(),
             ],
         ];
+    }
+
+    /**
+     * @return string
+     *
+     * NEXT_MAJOR: Make this method abstract
+     */
+    protected function getFilterTypeClass()
+    {
+        @trigger_error(
+            __METHOD__.' should be implemented. It will be abstract in 2.0.',
+            E_USER_DEPRECATED
+        );
+
+        return DateTimeType::class;
     }
 
     /**

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminSearchBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\CoreBundle\Form\Type\BooleanType;
 
 class BooleanFilter extends Filter
@@ -74,7 +75,7 @@ class BooleanFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => 'hidden',

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminSearchBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 
 class CallbackFilter extends Filter
 {
@@ -47,7 +48,7 @@ class CallbackFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminSearchBundle\Filter;
 use Elastica\Util;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 
 class ChoiceFilter extends Filter
 {
@@ -81,7 +82,7 @@ class ChoiceFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
             'operator_type' => 'sonata_type_equal',
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminSearchBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\CoreBundle\Form\Type\EqualType;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList;
 
@@ -76,7 +77,7 @@ class ClassFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
             'operator_type' => 'sonata_type_equal',
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),

--- a/src/Filter/DateRangeFilter.php
+++ b/src/Filter/DateRangeFilter.php
@@ -11,19 +11,26 @@
 
 namespace Sonata\AdminSearchBundle\Filter;
 
-class DateRangeFilter extends AbstractDateFilter
+use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
+
+class DateRangeFilter extends AbstractDateFilter implements RangeFilterInterface
 {
     /**
      * This is a range filter.
      *
      * @var bool
+     *
+     * NEXT_MAJOR: Remove this property
+     *
+     * @deprecated since 1.x, will be removed in 2.0.
      */
     protected $range = true;
 
     /**
-     * This filter has time.
-     *
-     * @var bool
+     * {@inheritdoc}
      */
-    protected $time = false;
+    protected function getFilterTypeClass()
+    {
+        return DateRangeType::class;
+    }
 }

--- a/src/Filter/DateTimeFilter.php
+++ b/src/Filter/DateTimeFilter.php
@@ -11,19 +11,26 @@
 
 namespace Sonata\AdminSearchBundle\Filter;
 
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
+
 class DateTimeFilter extends AbstractDateFilter
 {
     /**
      * This filter has time.
      *
      * @var bool
+     *
+     * NEXT_MAJOR: Remove this property
+     *
+     * @deprecated since 1.x, will be removed in 2.0.
      */
     protected $time = true;
 
     /**
-     * This is not a rangle filter.
-     *
-     * @var bool
+     * {@inheritdoc}
      */
-    protected $range = false;
+    protected function getFilterTypeClass()
+    {
+        return DateTimeType::class;
+    }
 }

--- a/src/Filter/DateTimeRangeFilter.php
+++ b/src/Filter/DateTimeRangeFilter.php
@@ -11,12 +11,18 @@
 
 namespace Sonata\AdminSearchBundle\Filter;
 
-class DateTimeRangeFilter extends AbstractDateFilter
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
+
+class DateTimeRangeFilter extends AbstractDateFilter implements RangeFilterInterface
 {
     /**
      * This Filter allows filtering by time.
      *
      * @var bool
+     *
+     * NEXT_MAJOR: Remove this property
+     *
+     * @deprecated since 1.x, will be removed in 2.0.
      */
     protected $time = true;
 
@@ -24,6 +30,18 @@ class DateTimeRangeFilter extends AbstractDateFilter
      * This is a range filter.
      *
      * @var bool
+     *
+     * NEXT_MAJOR: Remove this property
+     *
+     * @deprecated since 1.x, will be removed in 2.0.
      */
     protected $range = true;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFilterTypeClass()
+    {
+        return DateTimeRangeType::class;
+    }
 }

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminSearchBundle\Filter;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\CoreBundle\Form\Type\EqualType;
 
 class ModelFilter extends Filter
@@ -58,7 +59,7 @@ class ModelFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -62,7 +62,7 @@ class NumberFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_number', [
+        return [NumberType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/RangeFilterInterface.php
+++ b/src/Filter/RangeFilterInterface.php
@@ -11,15 +11,9 @@
 
 namespace Sonata\AdminSearchBundle\Filter;
 
-use Sonata\AdminBundle\Form\Type\Filter\DateType;
-
-class DateFilter extends AbstractDateFilter
+/**
+ * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ */
+interface RangeFilterInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFilterTypeClass()
-    {
-        return DateType::class;
-    }
 }

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -65,7 +65,7 @@ class StringFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_choice', [
+        return [ChoiceType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/TimeFilter.php
+++ b/src/Filter/TimeFilter.php
@@ -11,15 +11,19 @@
 
 namespace Sonata\AdminSearchBundle\Filter;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\TimeFilter class is deprecated since version 3.1 and will be removed in 4.0.'
+    .' Use '.__NAMESPACE__.'\DateTimeFilter instead.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * NEXT_MAJOR: Remove this class, this is same with DateTimeFilter class.
+ *
+ * @deprecated since 1.x, will be removed in 2.0. Use `Sonata\AdminSearchBundle\Filter\DateTimeFilter' instead.
+ */
 class TimeFilter extends AbstractDateFilter
 {
-    /**
-     * This filter has no range.
-     *
-     * @var bool
-     */
-    protected $range = false;
-
     /**
      * This filter does not allow filtering by time.
      *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminSearchBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because of the Symfony form deprecations.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #94

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Using `time` and `range` property in subclasses of `Sonata\AdminSearchBundle\Filter\AbstractDateFilter` is deprecated. Please implement `getFilterTypeClass` method which will be an abstract method.

### Fixed
- Deprecated strings type class names usage.

```

## To do

 - [x] Update the tests
 - [x] Add an upgrade note