### PR TITLE
CS fix

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -65,7 +65,7 @@ class Pager extends BasePager
 
     protected function getPaginator()
     {
-        if (is_null($this->paginator)) {
+        if (null === $this->paginator) {
             $this->paginator = $this->getQuery()->execute();
         }
 

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -191,7 +191,7 @@ abstract class AbstractDateFilter extends Filter
      */
     protected function getOperator($type)
     {
-        $type = intval($type);
+        $type = (int) $type;
 
         $choices = [
             DateType::TYPE_EQUAL => '=',


### PR DESCRIPTION
The build in #102 should be fixed afterwards

```
php-cs-fixer fix --verbose
You are running PHP CS Fixer with xdebug enabled. This has a major impact on runtime performance.
If you need help while solving warnings, ask at https://gitter.im/PHP-CS-Fixer, we will help you!
Loaded config default from "/home/travis/build/sonata-project/SonataAdminSearchBundle/.php_cs".
.......F...F..........................
Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes, F-fixed, E-error
   1) src/Datagrid/Pager.php (is_null)
   2) src/Filter/AbstractDateFilter.php (modernize_types_casting)
Fixed all files in 11.575 seconds, 16.500 MB memory used
git diff --exit-code
diff --git a/src/Datagrid/Pager.php b/src/Datagrid/Pager.php
index 036fed6..b838058 100644
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -65,7 +65,7 @@ class Pager extends BasePager
 
     protected function getPaginator()
     {
-        if (is_null($this->paginator)) {
+        if (null === $this->paginator) {
             $this->paginator = $this->getQuery()->execute();
         }
 
diff --git a/src/Filter/AbstractDateFilter.php b/src/Filter/AbstractDateFilter.php
index b9dabe1..0523684 100644
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -191,7 +191,7 @@ abstract class AbstractDateFilter extends Filter
      */
     protected function getOperator($type)
     {
-        $type = intval($type);
+        $type = (int) $type;
 
         $choices = [
             DateType::TYPE_EQUAL => '=',
```