### PR TITLE
Restore PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "friendsofsymfony/elastica-bundle": "^3.1",
         "pagerfanta/pagerfanta": "^1.0",
         "ruflin/elastica": "^2.1 || ^3.0",


### PR DESCRIPTION
After the back and forth of PHP versions, we lost 7.1 on master, which was not intended. This PR restores it.