### PR TITLE
Drop old versions of php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "friendsofsymfony/elastica-bundle": "^3.1",
         "pagerfanta/pagerfanta": "^1.0",
         "ruflin/elastica": "^2.1 || ^3.0",


### PR DESCRIPTION
## Subject
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for php 5 and php 7.0
```
